### PR TITLE
fix: add null check for agent in AgentProfileModal

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ x402-info --service-id <id>
 
 A full-featured web UI built with **Next.js 16** and **React 19.2**:
 
-**Live Demo:** [https://app-one-theta-63.vercel.app](https://app-one-theta-63.vercel.app)
+**Live Demo:** [https://agentpay-ten.vercel.app](https://agentpay-ten.vercel.app)
 
 ### Pages
 
@@ -239,24 +239,24 @@ Programmatic access via REST API:
 
 ```bash
 # List all services
-curl https://app-one-theta-63.vercel.app/api/v1/services
+curl https://agentpay-ten.vercel.app/api/v1/services
 
 # Get protocol stats
-curl https://app-one-theta-63.vercel.app/api/v1/stats
+curl https://agentpay-ten.vercel.app/api/v1/stats
 
 # Scan wallet for risks
-curl https://app-one-theta-63.vercel.app/api/v1/scan/3D9b6XfS7vs...
+curl https://agentpay-ten.vercel.app/api/v1/scan/3D9b6XfS7vs...
 ```
 
 See [docs/API-REFERENCE.md](./docs/API-REFERENCE.md) for full API documentation.
 
 ### Agent Registry
 
-Browse registered agents at [/agents](https://app-one-theta-63.vercel.app/agents) — view track records, services, ZK verification stats, and REKT Shield risk scores.
+Browse registered agents at [/agents](https://agentpay-ten.vercel.app/agents) — view track records, services, ZK verification stats, and REKT Shield risk scores.
 
 ## Live Demo
 
-**Web UI:** [https://app-one-theta-63.vercel.app](https://app-one-theta-63.vercel.app)
+**Web UI:** [https://agentpay-ten.vercel.app](https://agentpay-ten.vercel.app)
 
 Three AI agents running on Hetzner communicate autonomously:
 - **Provider** (`3D9b...`) — Registers services and completes tasks

--- a/app/src/components/agents/AgentProfileModal.tsx
+++ b/app/src/components/agents/AgentProfileModal.tsx
@@ -33,9 +33,11 @@ export function AgentProfileModal({ agent, open, onOpenChange }: AgentProfileMod
 
   // Fetch REKT Shield risk score
   useEffect(() => {
+    if (!agent) return;
+    
     async function fetchRiskScore() {
       try {
-        const res = await fetch(`/api/v1/scan/${agent.wallet}`);
+        const res = await fetch(`/api/v1/scan/${agent!.wallet}`);
         if (res.ok) {
           const data = await res.json();
           if (data.success && data.risk) {
@@ -54,7 +56,9 @@ export function AgentProfileModal({ agent, open, onOpenChange }: AgentProfileMod
       }
     }
     fetchRiskScore();
-  }, [agent.wallet]);
+  }, [agent]);
+
+  if (!agent) return null;
 
   const zkPercentage =
     agent.stats.totalTasksCompleted > 0
@@ -84,8 +88,6 @@ export function AgentProfileModal({ agent, open, onOpenChange }: AgentProfileMod
       : riskScore.level === "medium"
       ? "bg-[var(--color-warning)]/10"
       : "bg-[var(--color-error)]/10";
-
-  if (!agent) return null;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/mcp-server/teams-data/teams.json
+++ b/mcp-server/teams-data/teams.json
@@ -1,0 +1,1 @@
+{"teams": [], "teamTasks": [], "lastUpdated": 1770744108332}


### PR DESCRIPTION
## Problem
Vercel build failing with TypeScript error:
```
./src/components/agents/AgentProfileModal.tsx:38:49
Type error: 'agent' is possibly 'null'.
```

## Solution
- Added early return `if (!agent) return null;` before accessing agent properties
- Fixed useEffect dependency array (now depends on `agent` instead of `agent.wallet`)
- Added non-null assertion in fetch call since we guard above

## Testing
- Build should pass now
- Modal behavior unchanged (returns null when no agent selected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Live Demo and API endpoint references to reflect new deployment domain.
  * Expanded agent roles overview to include Client and Sentinel agent types.

* **Bug Fixes**
  * Improved stability when loading agent profiles with missing data.

* **Chores**
  * Added teams data structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->